### PR TITLE
support setBuiltInZoomControls control

### DIFF
--- a/src/android/com/kumbe/phonegap/zoom/ZoomControl.java
+++ b/src/android/com/kumbe/phonegap/zoom/ZoomControl.java
@@ -46,6 +46,25 @@ public class ZoomControl extends CordovaPlugin {
             });
             return true;
         }
+
+        if ("setBuiltInZoomControls".equals(action)) {
+            final WebView webView = this.webView;
+            cordova.getActivity().runOnUiThread(new Runnable() {
+                public void run() {
+                    try {
+                        boolean enabled=args.getBoolean(0);
+                        LOG.d("setBuiltInZoomControls", "executing setBuiltInZoomControls");
+                        webView.getSettings().setBuiltInZoomControls(enabled);
+                        callbackContext.success("OK");
+                    } catch (Exception e) {
+                        LOG.e("setBuiltInZoomControls", "Error: " + e.getMessage());
+                        callbackContext.error("Error: " + e.getMessage());
+                    }
+                }
+            });
+            return true;
+        }
+
         return false;
         
 	}

--- a/www/plugins.ZoomControl.js
+++ b/www/plugins.ZoomControl.js
@@ -8,6 +8,11 @@ ZoomControl.prototype.ZoomControl = function(enabled) {
 		alert("Error calling ZoomControl::ZoomControl:"+error);
 	}, "ZoomControl", "ZoomControl", [enabled]);
 };
+ZoomControl.prototype.setBuiltInZoomControls = function(enabled) {
+	exec(null, function(error){
+		alert("Error calling ZoomControl::setBuiltInZoomControls:"+error);
+	}, "ZoomControl", "setBuiltInZoomControls", [enabled]);
+};
 
 var ZoomControl = new ZoomControl();
 module.exports = ZoomControl;


### PR DESCRIPTION
Hello and thanks for the great plugin. It saved me. One detail that I need (and have added in this commit) is the ability to separately control the setBuiltInZoomControls parameter which I've added.

If you think this is OK please pull, increase the version of your plugin to 1.6 and resubmit to phonegap build.

thanks a lot
